### PR TITLE
Ship Clang builtin includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,9 @@ install(
     ${clang-tidy-executable}
   DESTINATION clang_tidy/data/bin
 )
+
+install(
+  DIRECTORY
+    ${CMAKE_BINARY_DIR}/llvm/lib/clang/${CLANG_TIDY_VERSION}/include
+  DESTINATION clang_tidy/data/lib/clang/${CLANG_TIDY_VERSION}
+)


### PR DESCRIPTION
This change fixes the issue referenced in Clang FAQ
https://clang.llvm.org/docs/FAQ.html#i-get-errors-about-some-headers-being-missing-stddef-h-stdarg-h

To reproduce the issue with 14.0.6:
```
$ docker run --rm -ti python bash
$ pip install clang-tidy==14.0.6
$ echo "include <iostream>" > foo.cpp
$ clang-tidy foo.cpp
Error while trying to load a compilation database:
Could not auto-detect compilation database for file "foo.cpp"
No compilation database found in / or any parent directory
fixed-compilation-database: Error while opening fixed database: No such file or directory
json-compilation-database: Error while opening JSON database: No such file or directory
Running without flags.
1 error generated.
Error while processing /foo.cpp.
/usr/include/wchar.h:35:10: error: 'stddef.h' file not found [clang-diagnostic-error]
         ^~~~~~~~~~
Found compiler error(s).
```