### PR TITLE
Add minimalistic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,8 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+# scikit-build cache
+_skbuild/
+
+clang_tidy/data/

--- a/clang_tidy/__init__.py
+++ b/clang_tidy/__init__.py
@@ -6,15 +6,24 @@ import sys
 def _get_executable(name):
     return os.path.join(os.path.dirname(__file__), "data", "bin", name)
 
-def _run(name):
-    executable = _get_executable(name)
-    return subprocess.call([executable] + sys.argv[1:])
+def _run(name, *args):
+    command = [_get_executable(name)]
+    if args:
+        command += list(args)
+    else:
+        command += sys.argv[1:]
+    return subprocess.call(command)
 
-def _run_python(name):
-    script = _get_executable(name)
+def _run_python(name, *args):
+    command = [sys.executable, _get_executable(name)]
+    if args:
+        command += list(args)
+    else:
+        command += sys.argv[1:]
+
     # as MS Windows is not able to run Python scripts directly by name,
     # we have to call the interpreter and pass the script as parameter
-    return subprocess.call([sys.executable, script] + sys.argv[1:])
+    return subprocess.call(command)
 
 
 def clang_tidy():

--- a/test/test_empty.py
+++ b/test/test_empty.py
@@ -1,2 +1,0 @@
-def test_nothing():
-    pass

--- a/test/test_executable.py
+++ b/test/test_executable.py
@@ -1,0 +1,21 @@
+import os
+import tempfile
+
+import clang_tidy
+
+
+def test_executable_file():
+    exe = clang_tidy._get_executable("clang-tidy")
+    assert os.path.exists(exe), "'clang-tidy' executable is missing"
+    assert os.access(exe, os.X_OK), "'clang-tidy'program is not executable"
+
+
+def test_include_iostream():
+    fd, compilation_unit = tempfile.mkstemp(suffix=".cpp")
+    os.close(fd)
+    with open(compilation_unit, "w") as ostr:
+        ostr.write("#include <iostream>\n")
+    try:
+        assert clang_tidy._run("clang-tidy", compilation_unit) == 0
+    finally:
+        os.remove(compilation_unit)

--- a/test/test_executable.py
+++ b/test/test_executable.py
@@ -1,5 +1,9 @@
 import os
+import sys
 import tempfile
+
+# test the installed clang_tidy package, not the local one
+sys.path.remove(os.path.dirname(os.path.dirname(__file__)))
 
 import clang_tidy
 


### PR DESCRIPTION
* ensure that clang-tidy binary file exists and is executable
* run clang-tidy on a very simple C++ file

Fixes #1