### PR TITLE
Add debugging information when test fails

### DIFF
--- a/test/test_executable.py
+++ b/test/test_executable.py
@@ -20,6 +20,6 @@ def test_include_iostream():
     with open(compilation_unit, "w") as ostr:
         ostr.write("#include <iostream>\n")
     try:
-        assert clang_tidy._run("clang-tidy", compilation_unit) == 0
+        assert clang_tidy._run("clang-tidy", "--extra-arg=-v", compilation_unit) == 0
     finally:
         os.remove(compilation_unit)


### PR DESCRIPTION
This PR intends to debug the failing MacOS build in the first place but might be useful anyway.