### PR TITLE
CI: set SDKROOT on macOS builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,10 @@ jobs:
       with:
         xcode-version: latest-stable
 
+    - name: Export macOS SDKROOT
+      if: runner.os == 'macOS'
+      run: echo SDKROOT=$(xcrun --sdk macosx --show-sdk-path) >> $GITHUB_ENV
+
     - name: Override LLVM version (${{ github.event.inputs.llvm_version }})
       if: github.event.inputs.llvm_version
       run: |


### PR DESCRIPTION
Unsetting the SDKROOT environment variable on my laptop makes clang-tidy fails the same way on my laptop as in the CI, see my comment https://github.com/ssciwr/clang-tidy-wheel/pull/13#issuecomment-1187615695
So setting it may fix the issue!