### PR TITLE
re enable qemu jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,16 +47,12 @@ jobs:
             arch: "i686"
             use_qemu: false
             skip: "*musllinux*"
-              # These take too long to build on Github
-              #- os: ubuntu-20.04
-              #arch: "aarch64"
-              #use_qemu: true
-              #- os: ubuntu-20.04
-              #arch: "ppc64le"
-              #use_qemu: true
-              #- os: ubuntu-20.04
-              #arch: "s390x"
-              #use_qemu: true
+          - os: self-hosted
+            arch: "aarch64"
+            use_qemu: true
+          - os: self-hosted
+            arch: "ppc64le"
+            use_qemu: true
           - os: windows-2022
             arch: "AMD64"
             use_qemu: false


### PR DESCRIPTION
- Ship Clang builtin includes
- Add minimalistic tests
- Workaround so that pytest don't see the local package
- Add debugging information when test fails
- CI: set SDKROOT on macOS builder
- [ci|gh] update MacOS images to current
- [ci] re-enable all qemu builders on self-hosted runner
- [ci] don't fail the matrix build early
