### PR TITLE
Move to MacOS 12 Runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
             arch: "x86"
             use_qemu: false
             skip: 
-          - os: macos-11
+          - os: macos-12
             arch: "x86_64"
             use_qemu: false
             skip: 


### PR DESCRIPTION
MacOS 11 has been removed from github. MacOS 12 are to be deprecated in October.