### PR TITLE
Enable a check when calling clang-tidy in tests

### DIFF
--- a/test/test_executable.py
+++ b/test/test_executable.py
@@ -37,7 +37,14 @@ def _test_code(code: str):
     with open(compilation_unit, "w") as ostr:
         ostr.write(code)
     try:
-        assert clang_tidy._run("clang-tidy", "--extra-arg=-v", compilation_unit) == 0
+        assert (
+            clang_tidy._run(
+                "clang-tidy",
+                "--checks=bugprone-infinite-loop",
+                "--extra-arg=-v",
+                compilation_unit,
+            ) == 0
+        )
     finally:
         os.remove(compilation_unit)
 


### PR DESCRIPTION
Per [version 22 release notes](https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html#improvements-to-clang-tidy), the clang static analyzer checkers were removed from being enabled by default.  Thus, no checks are enabled by default, which causes unit tests to end in an error message like the following:

```
Error: no checks enabled.
``` 

Enabling at least one check will prevent the error and allow tests to succeed.  I arbitrarily chose `bugprone-infinite-loop` since it seemed unlikely to every conflict with this repository's `clang-tidy` test cases.