### PR TITLE
Expose get_executable. Fixes #116

### DIFF
--- a/clang_tidy/__init__.py
+++ b/clang_tidy/__init__.py
@@ -10,6 +10,9 @@ if sys.version_info.minor >= 9:
 else:
     import pkg_resources
 
+def get_executable(name:str) -> Path:
+    return _get_executable(name)
+
 
 @functools.lru_cache(maxsize=None)
 def _get_executable(name:str) -> Path:

--- a/test/test_executable.py
+++ b/test/test_executable.py
@@ -23,7 +23,7 @@ def test_executable_file(capsys):
     import clang_tidy
 
     clang_tidy._get_executable.cache_clear()
-    exe = clang_tidy._get_executable("clang-tidy")
+    exe = clang_tidy.get_executable("clang-tidy")
     assert os.path.exists(exe)
     assert os.access(exe, os.X_OK)
     assert capsys.readouterr().out == ""
@@ -54,7 +54,7 @@ def test_verbose_output(capsys, monkeypatch):
     monkeypatch.setenv("CLANG_TIDY_WHEEL_VERBOSE", "1")
     # need to clear cache to make sure the function is run again
     clang_tidy._get_executable.cache_clear()
-    clang_tidy._get_executable("clang-tidy")
+    clang_tidy.get_executable("clang-tidy")
     assert capsys.readouterr().out
 
 


### PR DESCRIPTION
Add get_executable which wraps _get_executable. Purpose is to provide a publicly supported API for getting the executable path. Updated existing tests to use get_executable instead of _get_executable.