### PR TITLE
Add clang tidy utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ ExternalProject_add(build-clang-tidy
   USES_TERMINAL_CONFIGURE 1
   USES_TERMINAL_BUILD 1
   CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_ZSTD=OFF -DLLVM_ENABLE_PROJECTS=clang$<SEMICOLON>clang-tools-extra
-  BUILD_COMMAND ${CMAKE_COMMAND} --build . --target clang-tidy
+  BUILD_COMMAND ${CMAKE_COMMAND} --build . --target clang-tidy clang-apply-replacements
 )
 
 set(config-subfolder "")
@@ -28,6 +28,7 @@ if(CMAKE_GENERATOR MATCHES "Visual Studio")
   set(config-subfolder "Release")
 endif()
 set(clang-tidy-executable ${CMAKE_BINARY_DIR}/llvm/${config-subfolder}/bin/clang-tidy${CMAKE_EXECUTABLE_SUFFIX})
+set(clang-apply-replacements-executable ${CMAKE_BINARY_DIR}/llvm/${config-subfolder}/bin/clang-apply-replacements${CMAKE_EXECUTABLE_SUFFIX})
 
 # Reduce the size of the executable by executing strip if it is present on the system
 find_program(STRIP_EXECUTABLE strip)
@@ -36,15 +37,22 @@ if(STRIP_EXECUTABLE)
     strip-clang-tidy
     ALL
     COMMAND ${STRIP_EXECUTABLE} ${clang-tidy-executable}
-    COMMENT "Stripping clang-tidy executable for size reduction"
+    COMMAND ${STRIP_EXECUTABLE} ${clang-apply-replacements-executable}
+    COMMENT "Stripping clang-tidy and clang-apply-replacements executables for size reduction"
   )
   add_dependencies(strip-clang-tidy build-clang-tidy)
 endif()
+
+ExternalProject_Get_Property(build-clang-tidy SOURCE_DIR)
+set(llvm-source-dir "${SOURCE_DIR}")
 
 # Define an installation rule that copies the executable to our Python package
 install(
   PROGRAMS
     ${clang-tidy-executable}
+    ${clang-apply-replacements-executable}
+    ${llvm-source-dir}/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+    ${llvm-source-dir}/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
   DESTINATION clang_tidy/data/bin
 )
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 [![PyPI Release](https://img.shields.io/pypi/v/clang-tidy.svg)](https://pypi.org/project/clang-tidy)
 
-This project packages the `clang-tidy` utility as a Python package. It allows you to install `clang-tidy` directly from PyPI:
+This project packages the `clang-tidy` utility and related tools as a Python package. It allows you to install `clang-tidy` directly from PyPI:
 
 ```
 python -m pip install clang-tidy
 ```
+
+The tools provided are:
+- `clang-tidy`: lints C++ source code using configurable rules
+- `clang-apply-replacements`: applies "fixes" that have been exported by `clang-tidy` in YAML format
+- `run-clang-tidy.py`: runs `clang-tidy` over all files in a compilation database or a specified path, with parallelism
+- `clang-tidy-diff.py`: applies `clang-tidy` to the changed lines in a user-provided diff
 
 This projects intends to release a new PyPI package for each major and minor release of `clang-tidy`.
 

--- a/clang_tidy/__init__.py
+++ b/clang_tidy/__init__.py
@@ -33,7 +33,8 @@ def _get_executable(name:str) -> Path:
                 print(f'Found binary: {exe} ')
             return exe
 
-    raise FileNotFoundError(f"No executable found for {name} at\n{possibles}")
+    possibles_str = "\n\t".join(map(str, possibles))
+    raise FileNotFoundError(f"No executable found for {name} at\n\t{possibles_str}")
 
 def _run(name, *args):
     command = [_get_executable(name)]

--- a/clang_tidy/__init__.py
+++ b/clang_tidy/__init__.py
@@ -59,3 +59,13 @@ def clang_tidy():
     raise SystemExit(_run("clang-tidy"))
 
 
+def clang_apply_replacements():
+    raise SystemExit(_run("clang-apply-replacements"))
+
+
+def run_clang_tidy():
+    raise SystemExit(_run_python("run-clang-tidy.py"))
+
+
+def clang_tidy_diff():
+    raise SystemExit(_run_python("clang-tidy-diff.py"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ Source = "https://github.com/ssciwr/clang-tidy-wheel"
 
 [project.scripts]
 "clang-tidy" = "clang_tidy:clang_tidy"
+"clang-apply-replacements" = "clang_tidy:clang_apply_replacements"
+"run-clang-tidy.py" = "clang_tidy:run_clang_tidy"
+"clang-tidy-diff.py" = "clang_tidy:clang_tidy_diff"
 
 [tool.scikit-build]
 wheel.packages = ["clang_tidy"]

--- a/test/test_executable.py
+++ b/test/test_executable.py
@@ -6,6 +6,14 @@ from pathlib import Path
 import pytest
 
 
+EXECUTABLES = (
+    "clang-tidy",
+    "clang-apply-replacements",
+    "run-clang-tidy.py",
+    "clang-tidy-diff.py",
+)
+
+
 @pytest.fixture(autouse=True)
 def ensure_tidy_from_wheel(monkeypatch):
     """test the installed clang_tidy package, not the local one"""
@@ -19,11 +27,12 @@ def ensure_tidy_from_wheel(monkeypatch):
     monkeypatch.delitem(sys.modules, "clang_tidy", raising=False)
 
 
-def test_executable_file(capsys):
+@pytest.mark.parametrize("executable", EXECUTABLES)
+def test_executable_file(capsys, executable):
     import clang_tidy
 
     clang_tidy._get_executable.cache_clear()
-    exe = clang_tidy.get_executable("clang-tidy")
+    exe = clang_tidy.get_executable(executable)
     assert os.path.exists(exe)
     assert os.access(exe, os.X_OK)
     assert capsys.readouterr().out == ""


### PR DESCRIPTION
Add three `clang-tidy`-related utilities.  From the `README.md` file:

- `clang-apply-replacements`: applies "fixes" that have been exported by `clang-tidy` in YAML format
- `run-clang-tidy.py`: runs `clang-tidy` over all files in a compilation database or a specified path, with parallelism
- `clang-tidy-diff.py`: applies `clang-tidy` to the changed lines in a user-provided diff

Closes #121.